### PR TITLE
fixed the strength on SkyblockPlayerAttributes

### DIFF
--- a/src/main/kotlin/zone/nora/slothpixel/skyblock/players/attributes/SkyblockPlayerAttributes.kt
+++ b/src/main/kotlin/zone/nora/slothpixel/skyblock/players/attributes/SkyblockPlayerAttributes.kt
@@ -16,7 +16,7 @@ class SkyblockPlayerAttributes {
     val effectiveHealth = 0
 
     @SerializedName("strength")
-    val strength = 0
+    val strength = ""
 
     @SerializedName("damage_increase")
     val damageIncrease = 0.0


### PR DESCRIPTION
So it seems like they changed the Slothpixel Api to return the strength of a player in Skyblock in roman numerals instead of a number. 
So I changed the strength in SkyblockPlayerAttributes to be an empty String instead of 0
![Image of the Roman numeral](https://user-images.githubusercontent.com/22573233/105222640-0e992080-5b5b-11eb-927f-c9b6c770f0f4.png)
